### PR TITLE
Merge webpack config dev and prod files(working with CRA-2.1.2)

### DIFF
--- a/packages/cli/scripts/build.js
+++ b/packages/cli/scripts/build.js
@@ -5,8 +5,8 @@ const {webpack: transforms} = gatherPipes(['webpack'])
 
 const patch = require('../patch')
 const {paths} = require('@rescripts/utilities')
-const {webpackConfigProd, build} = paths
+const {webpackConfig, build} = paths
 
-patch(transforms, webpackConfigProd)
+patch(transforms, webpackConfig)
 
 require(build)

--- a/packages/cli/scripts/start.js
+++ b/packages/cli/scripts/start.js
@@ -9,10 +9,10 @@ const {
 const {forEach} = require('ramda')
 const patch = require('../patch')
 const {paths} = require('@rescripts/utilities')
-const {webpackConfigDev, webpackDevServerConfig, start} = paths
+const {webpackConfig, webpackDevServerConfig, start} = paths
 
 forEach(args => patch(...args), [
-  [webpackTransforms, webpackConfigDev],
+  [webpackTransforms, webpackConfig],
   [devServerTransforms, webpackDevServerConfig],
 ])
 

--- a/packages/utilities/paths.js
+++ b/packages/utilities/paths.js
@@ -27,8 +27,7 @@ const rekeyMap = {
 }
 
 const configs = {
-  webpackConfigDev: 'config/webpack.config.dev',
-  webpackConfigProd: 'config/webpack.config.prod',
+  webpackConfig: 'config/webpack.config',
   webpackDevServerConfig: 'config/webpackDevServer.config',
   createJestConfig: 'scripts/utils/createJestConfig',
 }


### PR DESCRIPTION
Since CRA 2.1.2 has already merged webpack configurations: [PR#5722](https://github.com/facebook/create-react-app/pull/5722/files), rescripts will not work for that version.
So simply, if we stop supporting the previous CRA versions, this PR should work.